### PR TITLE
cont-init.d script to check for libseccomp2 issues

### DIFF
--- a/00-libseccomp2
+++ b/00-libseccomp2
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-if [[ ! sleep 0 > /dev/null 2>&1 ]]; then
+if ! sleep 0 >/dev/null 2>&1; then
 	echo "########################################################################"
 	echo "######### YOU NEED TO UPDATE YOUR SYSTEM TO RUN THIS CONTAINER #########"
 	echo "Please visit: https://github.com/sdr-enthusiasts/Buster-Docker-Fixes"

--- a/00-libseccomp2
+++ b/00-libseccomp2
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bash
+# shellcheck shell=bash
+
+if [[ ! sleep 0 > /dev/null 2>&1 ]]; then
+	echo "########################################################################"
+	echo "######### YOU NEED TO UPDATE YOUR SYSTEM TO RUN THIS CONTAINER #########"
+	echo "Please visit: https://github.com/sdr-enthusiasts/Buster-Docker-Fixes"
+	echo "########################################################################"
+
+	exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Buster on 32-bit ARM Docker Fixes
+# Buster Docker Fixes
 
 ## The situation
 
-Users running 32-bit Debian "Buster"-based operating systems (e.g., Raspbian/Raspberry Pi OS 1.3) on ARM hardware (e.g., Raspberry Pi) may have issues running certain Docker containers.
+Users running Debian "Buster"-based operating systems (e.g., Raspbian/Raspberry Pi OS 1.3) on ARM hardware (e.g., Raspberry Pi) may have issues running certain Docker containers.
 
 Newer Docker containers can be based on Debian "Bullseye", the latest stable branch of Debian Linux. Newer versions of Linux are generally better maintained and receive timely bug fixes and security updates for installed packages.
 
 ## The problem
 
-Users of older 32-bits "Buster" based ARM systems may experience problems running "Bullseye" based Docker Containers. For example, you may see errors in the logs indicating issues with the `RTC` or `Real Time Clock`. This is an example of such error message:
+Users of older "Buster" based ARM systems may experience problems running "Bullseye" based Docker Containers. For example, you may see errors in the logs indicating issues with the `RTC` or `Real Time Clock`. This is an example of such error message:
 
 ```
 sleep: cannot read realtime clock: Operation not permitted

--- a/libseccomp2-checker.sh
+++ b/libseccomp2-checker.sh
@@ -91,6 +91,6 @@ then
 	[[ ${A:0:1} == "y" ]] && docker restart $(docker ps -q)
 	echo "Done!"
 else
-	echo "Something went wrong. Please try running the script again! If that doesn't work, please file an issue at https://github.com/fredclausen/Buster-Docker-Fixes/issues" 
+	echo "Something went wrong. Please try running the script again! If that doesn't work, please file an issue at https://github.com/sdr-enthusiasts/Buster-Docker-Fixes/issues" 
 	echo "and we will try to help you."
 fi


### PR DESCRIPTION
This script will cause the container to not start if libseccomp2 is bad. Unfortunately, it is untested, but at first blush I can't see why it wouldn't work.