### PR TITLE
exit on any failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Buster (and Stretch) Docker Fixes
-[](https://discord.com/channels/@me/804331474513690625/940387433797799980 =200x)
+<img source="https://raw.githubusercontent.com/sdr-enthusiasts/sdr-enthusiast-assets/main/SDR%20Enthusiasts.svg" height="200">
+
 ## The situation
 
 Users running Debian "Stretch" or "Buster"-based operating systems (e.g., Raspbian/Raspberry Pi OS 1.3) on ARM hardware (e.g., Raspberry Pi) may have issues running certain Docker containers.
@@ -59,6 +60,12 @@ The `libseccomp2` script will do the following things to your system:
 
 You may be prompted for a password because the script is modifying things that require escalated (`sudo`) privileges.
 Feel free to inspect the script [here](libseccomp2-checker.sh).
+
+Finally -- if you have a very old OS, the script may error out with the message below. In that case, first do `sudo apt update && sudo apt upgrade` and follow the instructions. Once done, run the script again.
+```
+E: Repository 'http://archive.raspberrypi.org/debian buster InRelease' changed its 'Suite' value from 'stable' to 'oldstable'
+N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
+```
 
 ## LICENSE
 This repository, including any scripts, data, SDKs, and documentation is subject to the MIT License, [included](LICENSE) with this package. Copyright (c) 2021, 2022 by Ramon F. Kolb (kx1t), Fred Clausen, Mike Nye, and others.

--- a/libseccomp2-checker.sh
+++ b/libseccomp2-checker.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+trap 'echo "[ERROR] Error in line $LINENO when executing: $BASH_COMMAND". Please fix the issue and run the script again.' ERR
 #
 # This script updates a STRETCH or BUSTER Debian distribution so it will have the latest version of libseccomp2.
 # The upgrade is necessary to run Bullseye-based Docker containers on a Buster host system.

--- a/libseccomp2-checker.sh
+++ b/libseccomp2-checker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 #
 # This script updates a STRETCH or BUSTER Debian distribution so it will have the latest version of libseccomp2.
 # The upgrade is necessary to run Bullseye-based Docker containers on a Buster host system.
@@ -26,7 +27,7 @@
 # SOFTWARE.
 #
 # Welcome message:
-echo "Welcome to the libseccomp2 upgrade script for Debian Stretch and Buster. This script is meant to be run on Raspberry Pi Buster-based systems that have Docker containers"
+echo "Welcome to the libseccomp2 upgrade script for Debian Stretch and Buster. This script is meant to be run on Raspberry Pi Buster/Stretch-based systems that have Docker containers"
 echo "that run Debian Bullseye or later. For this, the \"libseccomp2\" library version must be 2.4 or later."
 echo "This script will check this, and upgrade the library as necessary."
 echo ""
@@ -35,7 +36,7 @@ echo ""
 
 # Make sure we are indeed running a Debian Buster (Raspberry Pi OS) system:
 OS_VERSION="$(sed -n 's/\(^\s*VERSION_CODENAME=\)\(.*\)/\2/p' /etc/os-release)"
-[[ "$OS_VERSION" == "" ]] && OS_VERSION="$(sed -n 's/^\s*VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)"
+[[ "$OS_VERSION" == "" ]] && OS_VERSION="$(sed -n 's/^\s*VERSION=.*(\(.*\)).*/\1/p' /etc/os-release)" || true
 OS_VERSION=${OS_VERSION^^}
 if [[ "$OS_VERSION" != "BUSTER" ]] && [[ "$OS_VERSION" != "STRETCH" ]] && [[ "${1,,}" != "override" ]]
 then
@@ -94,7 +95,7 @@ then
 	echo "Upgrade complete. Your system now uses libseccomp2 version $(apt-cache policy libseccomp2|sed -n 's/\s*Installed:\s*\(.*\)/\1/p')."
 	read -rp "For this fix to be applied, you should restart all of your containers. Do you want us to do this for you? (Y/n) " A </dev/tty
 	[[ "$A" == "" ]] && A="y" || A=${A,,}
-	[[ ${A:0:1} == "y" ]] && docker restart $(docker ps -q)
+	[[ ${A:0:1} == "y" ]] && docker restart $(docker ps -q) || true
 	echo "Done!"
 else
 	echo "Something went wrong. Please try running the script again! If that doesn't work, please file an issue at https://github.com/sdr-enthusiasts/Buster-Docker-Fixes/issues"


### PR DESCRIPTION
Exit on failure - this change was triggered by `sudo apt update -q && sudo apt upgrade -y -q` failing on older Buster ysstems because they first need to explicitly accept moving their repo from `testing` or `stable` to `oldstable`.